### PR TITLE
Replace delete_undef_values for built-in filter function

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -83,7 +83,7 @@ class rhn_register (
 
   }
 
-  $final_args = delete_undef_values($arguments)
+  $final_args = $arguments.filter |$key, $val| { $val =~ NotUndef }
   $command_flags = command_args($final_args)
 
   if $rhn_register::force {

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "pcfens-rhn_register",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "author": "pcfens",
   "summary": "Register a server with RHN, Spacewalk, or Satellite.",
   "license": "Apache-2.0",


### PR DESCRIPTION
During an upgrade to puppet 6 we encountered the following error `Server Error: Evaluation Error: Error while evaluating a Function Call, Only strings, numerics, booleans, and arrays of strings and numerics can be be used in command line arguments but NilClass given.` 

By replacing the stdlib `delete_undef_values` function for the built-in `filter` function it starts working again.