### PR TITLE
replace legacy facts

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -28,8 +28,8 @@ class rhn_register (
   Optional[String]  $environment    = undef,
 ) {
 
-  if $::osfamily != 'RedHat' {
-    fail("You can't register ${::operatingsystem} with RHN or Satellite using this puppet module")
+  if $facts['os']['family'] != 'RedHat' {
+    fail("You can't register ${facts['os']['name']} with RHN or Satellite using this puppet module")
   }
 
   if $rhn_register::username == undef and $rhn_register::activationkey == undef or $activationkey == [] {

--- a/spec/classes/rhn_register_spec.rb
+++ b/spec/classes/rhn_register_spec.rb
@@ -4,8 +4,7 @@ describe 'rhn_register' do
   context 'On a RedHat system' do
     let :facts do
       {
-        osfamily: 'RedHat',
-        operatingsystem: 'RedHat',
+        os: {family: 'RedHat', name: 'RedHat'},
       }
     end
 
@@ -106,8 +105,7 @@ describe 'rhn_register' do
   context 'On an Ubuntu system' do
     let :facts do
       {
-        osfamily: 'Debian',
-        operatingsystem: 'Ubuntu',
+        os: {family: 'Debian', name: 'Ubuntu'},
       }
     end
 


### PR DESCRIPTION
Puppet 8 agents default to not sending legacy facts